### PR TITLE
fix [#1788]: preserve slashes in filename and match browser behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,11 @@ And much more..
 
 <p align="center"><b>Sponsors</b></p>
 
-<p align="center"><a href="https://sentry.io/"><img alt="Sentry" width="50px" src="https://avatars.githubusercontent.com/u/1396951?s=200&v=4"></a></p>
+<p align="center">
+    <a href="https://sentry.io/"><img alt="Sentry" width="50px" src="https://avatars.githubusercontent.com/u/1396951?s=200&v=4"></a>
+    &nbsp;&nbsp;
+    <a href="https://canonical.com/"><img alt="Canonical" width="50px" src="https://avatars.githubusercontent.com/u/53057619?s=200&v=4"></a>
+</p>
 
 <p align="center"><b>Backers</b></p>
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ And much more..
  - [Vue](https://vuejs.org/)
  - [React](https://reactjs.org)
  - [Svelte](https://svelte.dev/)
- - [Angular](https://angular.io/)
+ - [Angular](https://angular.dev/)
 
 ## Sponsors
 

--- a/packages/happy-dom/README.md
+++ b/packages/happy-dom/README.md
@@ -22,7 +22,7 @@ And much more..
 
 ## Works With
 
-[Vitest](https://vitest.dev/) | [Bun](https://bun.sh) | [Jest](https://jestjs.io/) | [Testing Library](https://testing-library.com/) | [Google LitElement](https://lit.dev/) | [Vue](https://vuejs.org/) | [React](https://reactjs.org) | [Svelte](https://svelte.dev/) | [Angular](https://angular.io/)
+[Vitest](https://vitest.dev/) | [Bun](https://bun.sh) | [Jest](https://jestjs.io/) | [Testing Library](https://testing-library.com/) | [Google LitElement](https://lit.dev/) | [Vue](https://vuejs.org/) | [React](https://reactjs.org) | [Svelte](https://svelte.dev/) | [Angular](https://angular.dev/)
 
 ## Module Systems
 

--- a/packages/happy-dom/src/file/File.ts
+++ b/packages/happy-dom/src/file/File.ts
@@ -37,7 +37,7 @@ export default class File extends Blob {
 
 		super(bits, options);
 
-		this.name = name.replace(/\//g, ':');
+		this.name = name;
 		this.lastModified = options && options.lastModified ? options.lastModified : Date.now();
 	}
 }

--- a/packages/happy-dom/src/nodes/html-anchor-element/HTMLAnchorElement.ts
+++ b/packages/happy-dom/src/nodes/html-anchor-element/HTMLAnchorElement.ts
@@ -411,7 +411,7 @@ export default class HTMLAnchorElement extends HTMLElement implements IHTMLHyper
 			!event[PropertySymbol.defaultPrevented] &&
 			event.type === 'click' &&
 			event instanceof MouseEvent &&
-			event.eventPhase === EventPhaseEnum.none
+			(event.eventPhase === EventPhaseEnum.none || event.eventPhase === EventPhaseEnum.bubbling)
 		) {
 			const href = this.href;
 

--- a/packages/happy-dom/test/nodes/html-anchor-element/HTMLAnchorElement.test.ts
+++ b/packages/happy-dom/test/nodes/html-anchor-element/HTMLAnchorElement.test.ts
@@ -417,6 +417,39 @@ describe('HTMLAnchorElement', () => {
 			expect(newWindow.closed).toBe(true);
 		});
 
+		it('Navigates the browser when a "click" event bubbles up to an element.', async () => {
+			const browser = new Browser();
+			const page = browser.newPage();
+			const window = page.mainFrame.window;
+
+			vi.spyOn(Fetch.prototype, 'send').mockImplementation(function (): Promise<Response> {
+				return Promise.resolve(<Response>{
+					text: () => Promise.resolve('Test')
+				});
+			});
+
+			const divElement = window.document.createElement('div');
+			const anchorElement = <HTMLAnchorElement>window.document.createElement('a');
+			anchorElement.href = 'https://www.example.com';
+			anchorElement.appendChild(divElement);
+			window.document.body.appendChild(anchorElement);
+
+			divElement.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+
+			const newWindow = page.mainFrame.window;
+
+			expect(newWindow === window).toBe(false);
+			expect(newWindow.location.href).toBe('https://www.example.com/');
+
+			await browser.waitUntilComplete();
+
+			expect(newWindow.document.body.innerHTML).toBe('Test');
+
+			newWindow.close();
+
+			expect(newWindow.closed).toBe(true);
+		});
+
 		it('Navigates the browser when a "click" event is dispatched on an element with target "_blank".', async () => {
 			const browser = new Browser();
 			const page = browser.newPage();


### PR DESCRIPTION
The File constructor was incorrectly replacing slashes (/) in the filename with colons (:), resulting in names like "foo:bar.jpg" instead of the expected "foo/bar.jpg".

This commit updates the behavior to align with browser implementations:
- Slashes in the provided filename are preserved.

Reference: https://developer.mozilla.org/en-US/docs/Web/API/File/File#filename